### PR TITLE
feat(invoice generation): Sytem Creates invoice depending on a config

### DIFF
--- a/invoice/apps.py
+++ b/invoice/apps.py
@@ -51,6 +51,7 @@ DEFAULT_CONFIG = {
     # To be specified as "module_name.submodule.function_name"
     "bill_user_filter_function": None,
     "invoice_user_filter_function": None,
+    "system_generate_invoice_on_policy": True,
 }
 
 logger = logging.getLogger(__name__)
@@ -97,6 +98,7 @@ class InvoiceConfig(AppConfig, ConfigUtilMixin):
 
     bill_user_filter = None
     invoice_user_filter = None
+    system_generate_invoice_on_policy = True
 
     def ready(self):
         from core.models import ModuleConfiguration

--- a/invoice/signals.py
+++ b/invoice/signals.py
@@ -3,6 +3,7 @@ from core.service_signals import ServiceSignalBindType
 from django.contrib.contenttypes.models import ContentType
 from invoice.models import InvoiceLineItem
 from invoice.services import InvoiceService
+from .apps import InvoiceConfig
 
 
 def bind_service_signals():
@@ -28,4 +29,8 @@ def check_invoice_exist(**kwargs):
 
 
 def save_invoice_in_db(**kwargs):
-    InvoiceService.invoice_create(**kwargs)
+    if str(kwargs.get('sender')) == "<class 'calcrule_contribution_legacy.calculation_rule.ContributionPlanCalculationRuleProductModeling'>":
+        if InvoiceConfig.system_generate_invoice_on_policy:
+            InvoiceService.invoice_create(**kwargs)
+    else:
+        InvoiceService.invoice_create(**kwargs)


### PR DESCRIPTION
@dragos-dobre We noticed that when assigning a policy, the system automatically generates an associated invoice. However, there are cases where this should no longer be necessary—for example, in Comoros, where invoices are already created based on their management policies.

To address this, we’ve added control over system-generated invoices via a configurable variable, which should help. By default, this setting remains enabled (true), meaning invoices will continue to be generated natively unless manually adjusted