### PR TITLE
fix invoices query

### DIFF
--- a/invoice/gql/gql_types/invoice_types.py
+++ b/invoice/gql/gql_types/invoice_types.py
@@ -47,7 +47,7 @@ class InvoiceGQLType(DjangoObjectType, GenericFilterGQLTypeMixin):
                 insuree = Insuree.objects.filter(id=subject_object_dict['headInsureeId'], validity_to__isnull=True)
                 insuree = insuree.values('id', 'chf_id', 'uuid', 'last_name', 'other_names')
                 subject_object_dict['headInsuree'] = {
-                    underscore_to_camel(k): v for k, v in insuree.first().items()
+                    underscore_to_camel(k): v for k, v in (insuree.first() or {}).items()
                 }
             subject_object_dict = json.dumps(subject_object_dict, cls=DjangoJSONEncoder)
             return subject_object_dict


### PR DESCRIPTION
# Description

I made a single minimal fix in invoice/gql/gql_types/invoice_types.py:

Changed insuree.first().items() to (insuree.first() or {}).items() in resolve_subject.
This prevents a crash when no Insuree is found (first() returns None) and returns an empty headInsuree object instead.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f51e2e0d-51ff-4591-8712-27554571c4c9" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/99e8c26d-8ad1-459b-ab2e-3a1d6902dd9e" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
