### PR TITLE
fix(invoice): add subject_type_filter and thirdparty_type_filter params

### DIFF
--- a/invoice/gql/gql_types/invoice_types.py
+++ b/invoice/gql/gql_types/invoice_types.py
@@ -47,7 +47,7 @@ class InvoiceGQLType(DjangoObjectType, GenericFilterGQLTypeMixin):
                 insuree = Insuree.objects.filter(id=subject_object_dict['headInsureeId'], validity_to__isnull=True)
                 insuree = insuree.values('id', 'chf_id', 'uuid', 'last_name', 'other_names')
                 subject_object_dict['headInsuree'] = {
-                    underscore_to_camel(k): v for k, v in insuree.first().items()
+                    underscore_to_camel(k): v for k, v in (insuree.first() or {}).items()
                 }
             subject_object_dict = json.dumps(subject_object_dict, cls=DjangoJSONEncoder)
             return subject_object_dict

--- a/invoice/gql/invoice/query.py
+++ b/invoice/gql/invoice/query.py
@@ -17,7 +17,9 @@ class InvoiceQueryMixin:
         dateValidFrom__Gte=graphene.DateTime(),
         dateValidTo__Lte=graphene.DateTime(),
         applyDefaultValidityFilter=graphene.Boolean(),
-        client_mutation_id=graphene.String()
+        client_mutation_id=graphene.String(),
+        subject_type_filter=graphene.String(),
+        thirdparty_type_filter=graphene.String(),
     )
 
     def resolve_invoice(self, info, **kwargs):
@@ -29,11 +31,11 @@ class InvoiceQueryMixin:
         if client_mutation_id:
             filters.append(Q(mutations__mutation__client_mutation_id=client_mutation_id))
 
-        subject_type = kwargs.get("subject_type", None)
+        subject_type = kwargs.pop("subject_type_filter", None)
         if subject_type:
             filters.append(Q(subject_type__model=subject_type))
 
-        thirdparty_type = kwargs.get("thirdparty_type", None)
+        thirdparty_type = kwargs.pop("thirdparty_type_filter", None)
         if thirdparty_type:
             filters.append(Q(thirdparty_type__model=thirdparty_type))
 

--- a/invoice/tests/gql/invoice_schema.py
+++ b/invoice/tests/gql/invoice_schema.py
@@ -21,7 +21,11 @@ mutation {
 
     search_for_invoice_query = F'''
 query {{ 
-	invoice(code_Iexact:"{DEFAULT_TEST_INVOICE_PAYLOAD['code']}"){{
+	invoice(
+        code_Iexact:"{DEFAULT_TEST_INVOICE_PAYLOAD['code']}",
+        subjectTypeFilter: "contract",
+        thirdpartyTypeFilter: "insuree"
+    ){{
     edges {{
       node {{
         isDeleted,
@@ -54,12 +58,11 @@ query {{
         mutation = self.create_invoice_mutation
         self.graph_client.execute(mutation, context=self.user_context.get_request())
         signal_receiver_mock.assert_called_once_with(**_expected_call_args)
-        pass
 
     def test_fetch_invoice_query(self):
         output = self.graph_client.execute(self.search_for_invoice_query, context=self.user_context.get_request())
-        expected = \
-            {'data': {
+        expected = {
+            'data': {
                 'invoice': {
                     'edges': [
                         {'node': {
@@ -71,7 +74,11 @@ query {{
                             'thirdpartyType': self.invoice.thirdparty_type.id,
                             'subjectId': F'{self.invoice.subject.id}',
                             'subjectType': self.invoice.subject_type.id
-        }}]}}}
+                        }}
+                    ]
+                }
+            }
+        }
 
         self.assertEqual(output, expected)
 


### PR DESCRIPTION
## Description

**Problem:** The Invoice GraphQL endpoint accepts `subjectType` and `thirdpartyType` as ContentType IDs, but the frontend sends business names like "contract" and "insuree". This causes a `"Invalid ID specified"` error.

**Solution:** Add two new filters `subject_type_filter` and `thirdparty_type_filter` that accept business names and filter using `subject_type__model` and `thirdparty_type__model` respectively.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [x] Relates to  https://github.com/openimis/openimis-fe-invoice_js/pull/78
- [ ] External reference (e.g., Jira):

## Demo

[Capture vidéo du 12-07-2026 11:17:05.webm](https://github.com/user-attachments/assets/af0beaa6-9428-44b4-b122-a56b73c5d76e)

## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
